### PR TITLE
Wraps all expect_* functions in test_that for cleaner error message

### DIFF
--- a/R_checks/inputDB_check.R
+++ b/R_checks/inputDB_check.R
@@ -28,109 +28,137 @@ bulk_checks <- function(data) {
   with(d[1,],paste(Short, Region, Date, Sex, Metric, Measure, sep = "-")) %>% 
     message()
   
-# 1. can't have NAs in Value column
-expect_false(
-  any(is.na(d$Value))
-  )
+  # 1. can't have NAs in Value column
+  test_that("Can't have NAs in Value column", {
+    expect_false(
+      any(is.na(d$Value))
+    )
+  })
 
-# 2. All Country and entries in a subset must be identical and equal to 
-# the Country entry in rubric
-expect_true(
-  all(as.character(d$Country) == d$Country[1])
-  )
+  # 2. All Country and entries in a subset must be identical and equal to 
+  # the Country entry in rubric
+  test_that("All Country and entries in a subset must be identical and equal to the Country entry in rubric", {
+    expect_true(
+      all(as.character(d$Country) == d$Country[1])
+    )
+  })
 
-# 3. Age (chr) can only be coercible to integer or "UNK" or "TOT", no NAs
-expect_true(
-  all(d$Age %in% c(age_range, "TOT", "UNK"))
-  )
+  # 3. Age (chr) can only be coercible to integer or "UNK" or "TOT", no NAs
+  test_that("Age (chr) can only be coercible to integer or 'UNK' or 'TOT', no NAs", {
+    expect_true(
+      all(d$Age %in% c(age_range, "TOT", "UNK"))
+    )
+  })
 
-# 4. AgeInt can only be coercible to integer or NA (maybe we should just read 
-# it in as integer?)
-expect_true(
-  is.integer(d$AgeInt)
-  )
+  # 4. AgeInt can only be coercible to integer or NA (maybe we should just read 
+  # it in as integer?)
+  test_that("AgeInt can only be coercible to integer or NA", {
+    expect_true(
+      is.integer(d$AgeInt)
+    )
+  })
 
-# 5. AgeInt can only be NA for UNK or TOT
-expect_true(
-  all(is.na(d[d$Age %in% c("UNK", "TOT"), ]$AgeInt))
-  )
+  # 5. AgeInt can only be NA for UNK or TOT
+  test_that("AgeInt can only be NA for UNK or TOT", {
+    expect_true(
+      all(is.na(d[d$Age %in% c("UNK", "TOT"), ]$AgeInt))
+    )
+  })
 
-# 6. AgeInt must sum to 105
-if (nrow(d) == 1) {
-  expect_true(is.na(d$AgeInt))
-
+  # 6. AgeInt must sum to 105
+  if (nrow(d) == 1) {
+    test_that("AgeInt must sum to 105", {
+      expect_true(is.na(d$AgeInt))
+    })
   } else {
+
+    test_that("AgeInt must sum to 105", {
+      expect_equal(
+        sum(d$AgeInt, na.rm = TRUE),
+        105
+      )
+    })
     
-  expect_equal(
-    sum(d$AgeInt, na.rm = TRUE),
-    105
-  )
     # 7. Age(i) + AgeInt(i) must equal Age(i+1)
-  x <- d$Age[d$Age %in% age_range] %>% 
-  as.character() %>% 
-  as.integer() %>% 
-  diff()
-  
-  len_x <- length(x)
+    x <- d$Age[d$Age %in% age_range] %>% 
+      as.character() %>% 
+      as.integer() %>% 
+      diff()
+    
+    len_x <- length(x)
 
-  expect_identical(
-    d$AgeInt[1:len_x],
-    x
-  )
-}
+    # TODO: WHAT MESSAGE TO PUT HERE FOR TEST_THAT?
+    expect_identical(
+      d$AgeInt[1:len_x],
+      x
+    )
+  }
 
 
 
-# 8. Sex can only be "f", "m", or "b"
-expect_true(
-  all(d$Sex %in% c("m", "f", "b", "UNK"))
-)
+  # 8. Sex can only be "f", "m", or "b"
+  test_that("Sex can only be 'f', 'm', or 'b'", {
+    expect_true(
+      all(d$Sex %in% c("m", "f", "b", "UNK"))
+    )
+  })
 
-# 9. Date must be "DD.MM.YYYY", which will work with lubridate::dmy().
-# we already converted the Date to the %d.%m.%Y format. If the datat is 
-# wrongly added an NA is returned
-expect_false(
-  any(is.na(d$Date))
-)
+  # 9. Date must be "DD.MM.YYYY", which will work with lubridate::dmy().
+  # we already converted the Date to the %d.%m.%Y format. If the datat is 
+  # wrongly added an NA is returned
+  test_that("Date must be 'DD.MM.YYYY'", {
+    expect_false(
+      any(is.na(d$Date))
+    )
+  })
 
-# 10. Date can't be before 1/12/2019 and can't be later than today
+  # 10. Date can't be before 1/12/2019 and can't be later than today
+  # Build time range
+  dt <- seq(as.Date("2019-12-01"), 
+            by = "day", 
+            length.out = as.double(difftime(Sys.Date(), as.Date("2019-12-01")) + 1)
+            )
 
-# Build time range
-dt <- seq(as.Date("2019-12-01"), 
-    by = "day", 
-    length.out = as.double(difftime(Sys.Date(), as.Date("2019-12-01")) + 1)
-)
+  test_that("Date can't be before 1/12/2019 and can't be later than today", {
+    expect_true(
+      all(d$Date %in% dt)
+    )
+  })
 
-expect_true(
-  all(d$Date %in% dt)
-)
+  # 11. Metric can only be "Count", "Fraction", or "Ratio" (so far)
+  test_that('Metric can only be "Count", "Fraction", or "Ratio" (so far)', {
+    expect_true(
+      all(d$Metric %in% c("Count", "Fraction", "Ratio"))
+    )
+  })
 
-# 11. Metric can only be "Count", "Fraction", or "Ratio" (so far)
-expect_true(
-  all(d$Metric %in% c("Count", "Fraction", "Ratio"))
-  )
+  # 12. Measure can only be "Cases", "Deaths", "Tests", or "ASCFR" (so far)
+  test_that('Measure can only be "Cases", "Deaths", "Tests", or "ASCFR" (so far)', {
+    expect_true(
+      all(d$Measure %in% c("Cases", "Deaths", "Tests", "ASCFR"))
+    )
+  })
 
-# 12. Measure can only be "Cases", "Deaths", "Tests", or "ASCFR" (so far)
-expect_true(
-  all(d$Measure %in% c("Cases", "Deaths", "Tests", "ASCFR"))
-  )
+  # 13. Code must be a concatenation of Short and Date
+  # I don't think a code is necessary in the colected data. This can be build 
+  # later on in the scripts. Moreover, we might decided to change the format.
+  # The less details are collected the less chances of typos.
 
-# 13. Code must be a concatenation of Short and Date
-# I don't think a code is necessary in the colected data. This can be build 
-# later on in the scripts. Moreover, we might decided to change the format.
-# The less details are collected the less chances of typos.
+  # 14. No negatives in Value column
+  test_that('No negatives in Value column', {
+    expect_true(
+      all(d$Value >= 0)
+    )
+  })
 
-# 14. No negatives in Value column
-expect_true(
-  all(d$Value >= 0)
-  )
-
-# 15. duplicated group-by variables (Each combo of Code, Sex, Age, 
-# Measure can only be present once) - we've had instances of double-entry 
-# already. See duplicated()
-expect_false(
-  any(duplicated(paste(d$Code, d$Age)))
-  )
+  # 15. duplicated group-by variables (Each combo of Code, Sex, Age, 
+  # Measure can only be present once) - we've had instances of double-entry 
+  # already. See duplicated()
+    test_that('Duplicated group-by variables (Each combo of Code, Sex, Age, Measure can only be present once)', {
+      expect_false(
+        any(duplicated(paste(d$Code, d$Age)))
+      )
+  })
 
 } # end bulk_checks()
 # ------------------------------------------
@@ -191,4 +219,4 @@ run_checks <- function(inputDB, ShortCodes, logfile = "R_checks/log.txt"){
 
 
 
-  
+

--- a/R_checks/inputDB_check.R
+++ b/R_checks/inputDB_check.R
@@ -179,7 +179,7 @@ parse_log <- function(file = "Data/log.txt"){
 # ------------------------------------------
 # RUN VALIDATION HERE
 
-prep_data_check <- function(inputDB, ShortCodes){
+prep_data_check <- function(input_data, ShortCodes){
   input_data %>% 
     filter(Short %in% ShortCodes) %>% 
     mutate(Date = as.Date(Date, format = "%d.%m.%Y"),


### PR DESCRIPTION
Easy adaptation: just wraps all expect_* functions with test_that, pasting the error specific text as title such that all logs have the long and detailed error message rather than the expect_* fail error.

Moving now to the postprocessing