### PR TITLE
fixed sweden vax

### DIFF
--- a/Automation/00_hydra/Sweden.R
+++ b/Automation/00_hydra/Sweden.R
@@ -162,7 +162,9 @@ if (date_f > last_date_drive){
       select(
         Sex = starts_with("K")
         , Value = `Antal vaccinerade`
-        , Measure = Dosnummer
+        # Changed on 20210423 by Diego after codes changed
+        # , Measure = Dosnummer
+        , Measure = Vaccinationsstatus
       ) %>% 
       # filter(!grepl("^t", Sex, ignore.case = T)) %>% 
       mutate(
@@ -172,8 +174,11 @@ if (date_f > last_date_drive){
           # grepl("^t", Sex, ignore.case = T) ~ "UNK"
         ) 
         , Measure = case_when(
-          grepl("1", Measure, ignore.case = T) ~ "Vaccination1"
-          , grepl("2", Measure, ignore.case = T) ~ "Vaccination2"
+          # Changed on 20210423 by Diego after codes changed
+          grepl("inst 1 dos", Measure, ignore.case = T) ~ "Vaccination1"
+          , grepl("rdigvaccinerade", Measure, ignore.case = T) ~ "Vaccination2"
+          # grepl("1", Measure, ignore.case = T) ~ "Vaccination1"
+          # , grepl("2", Measure, ignore.case = T) ~ "Vaccination2"
         )
         , Age = "TOT"
         , AgeInt = ""
@@ -192,14 +197,17 @@ if (date_f > last_date_drive){
       filter(grepl("Sverige", Region)) %>% 
       select(
         Value = contains("antal")
-        , Measure = Dosnummer
+        # , Measure = Dosnummer
+        , Measure = Vaccinationsstatus
         , Age = ends_with("ldersgrupp")
       ) %>% 
       # filter(!grepl("^Total", Age)) %>% 
       mutate(
         Measure = case_when(
-          grepl("1", Measure, ignore.case = T) ~ "Vaccination1"
-          , grepl("2", Measure, ignore.case = T) ~ "Vaccination2"
+          # grepl("1", Measure, ignore.case = T) ~ "Vaccination1"
+          # , grepl("2", Measure, ignore.case = T) ~ "Vaccination2"
+          grepl("inst 1 dos", Measure, ignore.case = T) ~ "Vaccination1"
+          , grepl("rdigvaccinerade", Measure, ignore.case = T) ~ "Vaccination2"
         )
         , Age_low = as.numeric(str_extract(Age, "^[0-9]{2}"))
         , Age_high = as.numeric(str_extract(Age, "[0-9]{2}$"))


### PR DESCRIPTION
The Swedish script is failing in the data processing. Downloading and saving of the input data is still working, so no emergency. 
The issue was in the vaccine data. They renamed “Dosnummer” to “Vaccinationstatus” and also changed the coding for the number of doses. In addition to this, now, the script recodes Minst 1 dos = Vaccination1 and Färdigvaccinerade = Vaccination2.